### PR TITLE
Added rake task to inject data into solr

### DIFF
--- a/lib/tasks/mock_data.rake
+++ b/lib/tasks/mock_data.rake
@@ -6,7 +6,7 @@ namespace :data do
     Blacklight.solr
     Blacklight.solr.delete_by_query "*:*"
     Blacklight.solr.commit
-    file = File.join(Rails.root, 'tmp', 'mock_data.txt')
+    file = File.join(Rails.root, 'tmp', 'mock_data.json')
     Blacklight.solr.add(JSON.parse File.read(file))
     Blacklight.solr.commit
   end


### PR DESCRIPTION
By simply running rake data:mock, it will delete all information in your solr index, read from a file in tmp called mock_data.txt and commit that back into solr.
