### PR TITLE
Changed show page to show all relevant fields

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -55,6 +55,10 @@ class SolrDocument
     ].join("-|-")
   end
 
+  def filter_show_exceptions
+    key_filter.call
+  end
+
   private
 
   def file_distributor
@@ -62,6 +66,11 @@ class SolrDocument
     fd.source_site="http://oregondigital.library.oregonstate.edu/"
     fd.extension=".jpg"
     fd
+  end
+
+  def key_filter
+    kf = BuildingOregon::KeyFilter.new(self.keys, METADATA["Exceptions"])
+    kf
   end
 
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -69,8 +69,7 @@ class SolrDocument
   end
 
   def key_filter
-    kf = BuildingOregon::KeyFilter.new(self.keys, METADATA["Exceptions"])
-    kf
+    BuildingOregon::KeyFilter.new(self.keys, METADATA["Exceptions"])
   end
 
 end

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -5,11 +5,7 @@
   <% document.filter_show_exceptions.each do |field_name| -%>
     <dt class="blacklight-<%= field_name.parameterize %>"><%= render_document_show_field_label(document, field: field_name.gsub("desc_metadata__", "").gsub("ssm", "").gsub("ssim", "").gsub("label", "")) %></dt>
     <dd class="blacklight-<%= field_name.parameterize %>">
-    <% if(render_document_show_field_value document, field: field_name).include?("$") %>
-      <%= document.build_link(field_name).map(&:inspect).join(", ").gsub("\"", "") %>
-    <% else %>
-      <%= render_document_show_field_value document, field: field_name %>
-    <% end %>
+    <%= render_document_show_field_value document, field: field_name, :value => document.build_link(field_name) %>
     </dd>
   <% end -%>
 </dl>

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -2,12 +2,14 @@
 
 <%# default partial to display solr document fields in catalog show view -%>
 <dl class="dl-horizontal  dl-invert">
-  <% document_show_fields(document).each do |field_name, field| -%>
-    <% if should_render_show_field? document, field %>
-      <dt class="blacklight-<%= field_name.parameterize %>"><%= render_document_show_field_label document, field: field_name %></dt>
-      <dd class="blacklight-<%= field_name.parameterize %>">
-        <%= render_document_show_field_value document, field: field_name %>
-      </dd>
-    <% end -%>
+  <% document.filter_show_exceptions.each do |field_name| -%>
+    <dt class="blacklight-<%= field_name.parameterize %>"><%= render_document_show_field_label(document, field: field_name.gsub("desc_metadata__", "").gsub("ssm", "").gsub("ssim", "").gsub("label", "")) %></dt>
+    <dd class="blacklight-<%= field_name.parameterize %>">
+    <% if(render_document_show_field_value document, field: field_name).include?("$") %>
+      <%= document.build_link(field_name).map(&:inspect).join(", ").gsub("\"", "") %>
+    <% else %>
+      <%= render_document_show_field_value document, field: field_name %>
+    <% end %>
+    </dd>
   <% end -%>
 </dl>

--- a/config/metadata.yml
+++ b/config/metadata.yml
@@ -34,4 +34,4 @@ Exceptions:
    "desc_metadata__description_tesim", "desc_metadata__location_ssm", 
    "desc_metadata__type_ssm", "desc_metadata__format_ssm", "has_model_ssim", 
    "sort_date_desc_dtsi", "sort_date_asc_dtsi", "timestamp", "desc_metadata__rights_ssm", 
-   "desc_metadata__set_ssm"]
+   "desc_metadata__set_ssm", "desc_metadata__lat_ssm", "desc_metadata__long_ssm", "coords_ssim"]

--- a/config/metadata.yml
+++ b/config/metadata.yml
@@ -23,4 +23,15 @@ Index:
   creator: 'desc_metadata__creator_sim'
   material: 'desc_metadata__material_ssm'
   date: 'desc_metadata__temporal_ssm'
-  
+
+Exceptions:
+  ["reviewed_ssim", "has_thumbnail_bs", "system_create_dtsi", "system_modified_dtsi",
+   "object_state_ssi", "active_fedora_model_ssi", "id", "object_profile_ssm", 
+   "read_access_group_ssim", "workflow_metadata__reviewed_ssm", 
+   "workflow_metadata__reviewed_ssim", "workflow_metadata__has_thumbnail_ssm", 
+   "workflow_metadata__has_thumbnail_ssim", "desc_metadata__title_ssim", 
+   "desc_metadata__title_tesim", "desc_metadata__photographer_ssm", 
+   "desc_metadata__description_tesim", "desc_metadata__location_ssm", 
+   "desc_metadata__type_ssm", "desc_metadata__format_ssm", "has_model_ssim", 
+   "sort_date_desc_dtsi", "sort_date_asc_dtsi", "timestamp", "desc_metadata__rights_ssm", 
+   "desc_metadata__set_ssm"]

--- a/lib/building_oregon/catalog/show_config.rb
+++ b/lib/building_oregon/catalog/show_config.rb
@@ -4,9 +4,6 @@ module BuildingOregon
       extend ActiveSupport::Concern
       included do
         configure_blacklight do |config|
-          METADATA["Show"].each_pair do |field, metadata|
-            config.add_show_field metadata, :label => field, :accessor => :build_link
-          end
         end
       end
     end

--- a/lib/building_oregon/key_filter.rb
+++ b/lib/building_oregon/key_filter.rb
@@ -1,8 +1,8 @@
 module BuildingOregon
   class KeyFilter
     def initialize(keys, exceptions)
-      @keys = keys ||= {}
-      @exceptions = exceptions ||= []
+      @keys ||= keys
+      @exceptions = exceptions
     end
 
     def call

--- a/lib/building_oregon/key_filter.rb
+++ b/lib/building_oregon/key_filter.rb
@@ -1,7 +1,7 @@
 module BuildingOregon
   class KeyFilter
     def initialize(keys, exceptions)
-      @keys ||= keys
+      @keys = keys
       @exceptions = exceptions
     end
 

--- a/lib/building_oregon/key_filter.rb
+++ b/lib/building_oregon/key_filter.rb
@@ -1,0 +1,26 @@
+module BuildingOregon
+  class KeyFilter
+    def initialize(keys, exceptions)
+      @keys = keys ||= {}
+      @exceptions = exceptions ||= []
+    end
+
+    def call
+      filter_exceptions
+    end
+
+    def filter_exceptions
+      return @keys.delete_if{|key| contained_in_exceptions_list(key) }
+    end
+
+    def exceptions_list
+      @exceptions
+    end
+
+    private
+
+    def contained_in_exceptions_list(key)
+      exceptions_list.include?(key)
+    end
+  end
+end

--- a/spec/features/key_filter_spec.rb
+++ b/spec/features/key_filter_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+RSpec.describe BuildingOregon::KeyFilter do
+  let(:filter) {described_class.new(simple_array) }
+  let(:simple_array) {["stuff", "things", "banana", "yodawg"]}
+  let(:exceptions) {["stuff", "things"]}
+  let(:filtered_list) {["banana", "yodawg"]}
+  let(:key) {"stuff"}
+  describe "#exceptions_list" do
+    it "should return an array of keys" do
+      allow(filter).to receive(:exceptions_list).and_return(exceptions)
+      expect(filter.exceptions_list).to eq exceptions
+    end
+  end
+
+  describe "#filter_exceptions" do
+    it "should filter out the exceptions described within the object" do
+      allow(filter).to receive(:filter_exceptions).and_return(filtered_list)
+      expect(filter.filter_exceptions).to eq filtered_list
+    end
+  end
+
+  describe "#contained_in_exception_list" do
+    it "should return a true of false depending on if a key is contained in exceptions" do
+      allow(filter).to receive(:contained_in_exception_list).with(key).and_return(true)
+      expect(filter.contained_in_exception_list(key)).to eq true
+    end
+  end
+
+  context "When using the key filter" do
+    before do
+      filter.exceptions=exceptions
+    end
+    it "should take a list of keys and filter them based on exceptions" do
+      expect(filter.call).to eq filtered_list
+    end
+  end
+end

--- a/spec/features/key_filter_spec.rb
+++ b/spec/features/key_filter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe BuildingOregon::KeyFilter do
-  let(:filter) {described_class.new(simple_array) }
+  let(:filter) {described_class.new(simple_array, exceptions) }
   let(:simple_array) {["stuff", "things", "banana", "yodawg"]}
   let(:exceptions) {["stuff", "things"]}
   let(:filtered_list) {["banana", "yodawg"]}
@@ -28,9 +28,6 @@ RSpec.describe BuildingOregon::KeyFilter do
   end
 
   context "When using the key filter" do
-    before do
-      filter.exceptions=exceptions
-    end
     it "should take a list of keys and filter them based on exceptions" do
       expect(filter.call).to eq filtered_list
     end


### PR DESCRIPTION
This changes the implementation of the show page to show all fields that are attached to the document. It also implements a new object that filters out exceptions to what we want to display. The show page now displays all keys associated with said document that are not included within the exceptions list. Fixes #87, Fixes #38