### PR TITLE
Added the ajax-modal to excluded content

### DIFF
--- a/app/assets/javascripts/jpanel-activation.js
+++ b/app/assets/javascripts/jpanel-activation.js
@@ -3,6 +3,7 @@ $(document).ready(function() {
     menu: '#facets',
     trigger: '#button',
     duration: 300,
+    excludedPanelContent: "#ajax-modal"
   });
   jPM.on();
 });


### PR DESCRIPTION
Fixes #107 By exlcuding the ajax-modal from the jpanelmenu it is now allowed to function normally.