### PR TITLE
Added alignment for texts and searchbar

### DIFF
--- a/app/assets/javascripts/sidebar-facets.js
+++ b/app/assets/javascripts/sidebar-facets.js
@@ -1,6 +1,6 @@
 $(document).ready(function() {
   var width = $(window).width();
-  if(width < 1024 ){
+  if(width < 992 ){
     $("#facets").remove();
   }
 });

--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -37,7 +37,7 @@ form {
   border-color: white;
 }
 .move-down{
-  margin-top: 10px
+  margin-top: 4px
 }
 .black{
   background-color: black;
@@ -47,9 +47,22 @@ form {
   width: 300px;
 }
 
+@media(min-width: 1200px) {
+  .cite-navbar {
+    margin-right: -40px;
+    margin-left: 10px;
+  }
+}
+
 @media(min-width: 992px){
   #button{
     display: none;
+  }
+  .collapse.navbar-collapse {
+    margin-left: 20px;
+  }
+  #search-navbar {
+    margin-top: 2px;
   }
   .logo-size {
     top: 10%;
@@ -58,8 +71,9 @@ form {
     margin-left: -150px;
   }
   #user-util-collapse {
-    width: 200px;
+    width: 120px;
     padding-left: 0px;
+    margin-right: -50px;
   }
   .navbar-header {
     width: 100%;
@@ -68,7 +82,7 @@ form {
     width: 100%;
   }
   .navbar-form .form-control {
-    width: 50%;
+    width: 60%;
   }
   select#search_field.search_field.form-control {
     width: 100px;
@@ -81,7 +95,8 @@ form {
 @media(max-width: 991px){
   #header-navbar > .container {
     margin-left: 0px;
-    margin-right: 0px; 
+    margin-right: 0px;
+    height: 125px !important; 
   } 
   .navbar-inverse .navbar-form { 
     margin-top: 15px;
@@ -112,11 +127,12 @@ form {
     font-size: 15px;
   }
   .logo-size {
-    top: 10%;
+    top: 5%;
     left: 50%;
     position: absolute;
     margin-top: 5px;
     margin-left: -150px;
+    height: 80px;
   }
   #user-util-collapse {
     display: none !important;
@@ -129,6 +145,10 @@ form {
   }
   #header-navbar > .container {
     height: 150px;
+  }
+  #search-navbar {
+    margin-top: -20px;
+    margin-bottom: -20px;
   }
   .input-group {
     width: 100%;

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -41,6 +41,9 @@
       <li>
         <%= link_to t('blacklight.header_links.login'), new_user_session_path %>
       </li>
+      <li class="white">
+        Welcome, Guest
+      </li>
     <% end %>
   <% end %>
 </ul>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -16,7 +16,7 @@
             <%= image_tag "BO_Horizontal_White-04.svg", :class => "logo-size" %>
           </a>
         </div>
-        <div id="search-navbar" class="col-md-6 col-xs-12 col-sm-12 ">
+        <div id="search-navbar" class="col-md-7 col-xs-12 col-sm-12 ">
           <%= render_search_bar %>
         </div>
         <div class="col-md-2 collapse navbar-collapse" id="user-util-collapse">


### PR DESCRIPTION
The facets were disappearing too early, since we are transitioning to the mobile layout at 992px I needed to make the javascript that removes the facets emulate that. I also took out some vertical space within the navbar which on mobile versions slims the size of the screen up slightly. I also added welcome guest text for consistency of logged in vs not logged in.