### PR TITLE
Fix return value of update_map

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -312,7 +312,7 @@ GEM
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
     slop (3.6.0)
-    spring (1.1.3)
+    spring (1.3.6)
     spring-commands-rspec (1.0.2)
       spring (>= 0.9.1)
     sprockets (2.11.0)

--- a/app/assets/javascripts/update_map.js.coffee
+++ b/app/assets/javascripts/update_map.js.coffee
@@ -7,6 +7,7 @@ jQuery ->
       window.map?.locate(setView: true)
     else
       window.map?.fitBounds(window.markers.getBounds())
+  true
 class UserUpdater
   constructor: ->
   user_found: =>

--- a/app/assets/javascripts/update_map.js.coffee
+++ b/app/assets/javascripts/update_map.js.coffee
@@ -4,7 +4,9 @@ jQuery ->
     window.map?.on('moveend', window.UserUpdater.map_moved)
     window.map?.on('locationfound', window.UserUpdater.user_found)
     if window.location.search == ""
-      window.map?.locate(setView: true)
+      setTimeout ->
+        window.map?.locate(setView: true)
+      , 50
     else
       window.map?.fitBounds(window.markers.getBounds())
   true


### PR DESCRIPTION
This stops Safari from continuously executing the map location function.

Coffeescript has implicit returns, which bites you sometimes.