### PR TITLE
Various view changes. Removed useless admin link.

### DIFF
--- a/app/assets/stylesheets/blacklight_maps.css.scss
+++ b/app/assets/stylesheets/blacklight_maps.css.scss
@@ -1,3 +1,6 @@
 /*
 *= require blacklight_maps/default
 */
+#documents.map{
+  padding-top: 70px;
+}

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -1,4 +1,4 @@
-<h1>About Us</h1>
+<h1>About</h1>
 <% if @setting.blank? %>
 
 <% else %>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -4,7 +4,6 @@
       <div class="panel panel-default" id="dashboard">
         <div class="panel panel-heading"> Administration Dashboard </div>
         <div class="panel panel-body">
-          <p><%= link_to "Coordinate Object Information", admin_coordinates_path %></p>
           <p><%= link_to "Setting Information", admin_settings_path %></p>
         </div>
       </div>

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,4 +1,3 @@
-<h1>Building Oregon</h1>
 <% # container for all documents in map view -%>
 <div id="documents" class="map">
   <%= render "map" %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -16,7 +16,7 @@
       <div class="col-xs-12 col-md-offset-4 col-md-4">
         <p class="left">
           <a href="https://oregondigital.org/contact"> Contact Us </a> | 
-          <a href="https://oregondigital.org/copyright"> Copyrights </a> | 
+          <a href="https://oregondigital.org/copyright"> Copyright </a> | 
           <%= link_to "Help", help_path %> | 
           <%= link_to "About", about_index_path %>
         </p>

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -8,7 +8,6 @@ describe "admin" do
       visit admin_index_path
     end
     it "should display the admin panel" do
-      expect(page).to have_link("Coordinate Object Information")
       expect(page).to have_link("Setting Information")
     end
     context "when on the settings page" do


### PR DESCRIPTION
Fixes #199 About page fix.
Fixes #198 Copyright(s) fix.
Removes old coordinate link that was highly unnecessary.
Removes Building Oregon title above map.