### PR TITLE
changes the index information and formats, makes index picture a link removes comma

### DIFF
--- a/app/assets/javascripts/blacklight-maps-browse.js
+++ b/app/assets/javascripts/blacklight-maps-browse.js
@@ -172,7 +172,7 @@
         html += val;
         html += "</ul>";
       });
-      return html;
+      return html.replace("\n\n\n,","");
     }
 
     // Generates placenames object

--- a/app/helpers/facet_helper.rb
+++ b/app/helpers/facet_helper.rb
@@ -4,11 +4,9 @@ module FacetHelper
   end
 
   def controlled_index_label(label)
-    @value_array = []
-    label[:value].each do |value|
-      @value_array.append(BuildingOregon::ControlledValue.new(value).to_s)
+    label[:value].map do |value|
+      BuildingOregon::ControlledValue.new(value).to_s
     end
-    @value_array
   end
  
 

--- a/app/helpers/facet_helper.rb
+++ b/app/helpers/facet_helper.rb
@@ -3,4 +3,13 @@ module FacetHelper
     BuildingOregon::ControlledValue.new(label).to_s
   end
 
+  def controlled_index_label(label)
+    @value_array = []
+    label[:value].each do |value|
+      @value_array.append(BuildingOregon::ControlledValue.new(value).to_s)
+    end
+    @value_array
+  end
+ 
+
 end

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -1,7 +1,9 @@
 <div class="row">
   <dl class="document-metadata dl-horizontal dl-invert">
     <div class="col-md-2 col-sm-2">
-      <img class="thumbnail" src='<%= document.photo_path %>'>
+      <a href="<%= catalog_path(document.id) %>">
+        <img class="thumbnail" src='<%= document.photo_path %>'>
+      </a>
     </div>
     <div class="col-md-10 col-sm-10">
       <%= render :partial => "index_fields", :locals => {document:document} %>

--- a/app/views/catalog/_index_maps.html.erb
+++ b/app/views/catalog/_index_maps.html.erb
@@ -9,7 +9,9 @@
     <div class="col-md-12">
       <div class="row">
         <div class="col-md-6">
-          <img class="thumbnail" src="<%= document.photo_path %>">
+          <a href="<%= catalog_path(document.id) %>">
+            <img class="thumbnail" src="<%= document.photo_path %>">
+          </a>
         </div>
         <div class="col-md-6">
           <%= render :partial => "catalog/index_fields", :locals => {document:document} %>

--- a/config/metadata.yml
+++ b/config/metadata.yml
@@ -10,8 +10,9 @@ Facets:
 
 Index:
   creator: 'desc_metadata__creator_sim'
-  material: 'desc_metadata__material_ssm'
-  date: 'desc_metadata__temporal_ssm'
+  street address: 'desc_metadata__streetaddress_ssm'
+  photographer: 'desc_metadata__photographer_label_ssm'
+  date: 'desc_metadata__date_ssm'
 
 Exceptions:
   ["reviewed_ssim", "has_thumbnail_bs", "system_create_dtsi", "system_modified_dtsi",

--- a/lib/building_oregon/catalog/index_config.rb
+++ b/lib/building_oregon/catalog/index_config.rb
@@ -7,7 +7,7 @@ module BuildingOregon
           config.index.title_field = "desc_metadata__title_ssim"
 
           METADATA["Index"].each_pair do |field, metadata|
-            config.add_index_field metadata, :label => field
+            config.add_index_field metadata, :label => field.titleize, :helper_method => :controlled_index_label
           end
         end
       end

--- a/lib/building_oregon/field_sanitizer.rb
+++ b/lib/building_oregon/field_sanitizer.rb
@@ -19,7 +19,8 @@ module BuildingOregon
     end
 
     def map_multiword_field
-      @field = multi_word_fields[@field] if multi_word_fields.key?(@field) 
+      @new_field = multi_word_fields[@field] if multi_word_fields.key?(@field) 
+      @field.gsub!(@field, @new_field) unless @new_field.nil?
     end
 
     def remove_format
@@ -34,7 +35,7 @@ module BuildingOregon
         "ispartof" => "Is part of",
         "rightsholder" => "Rights Holder",
         "styleperiod" => "Style Period",
-        "viewdate" => "View Date",
+        "viewDate" => "View Date",
       }
     end
 

--- a/spec/values/field_sanitizer_spec.rb
+++ b/spec/values/field_sanitizer_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe BuildingOregon::FieldSanitizer do
   let(:field) { "desc_metadata__creatorDisplay_llsim" }
   let(:sanitizer) { described_class.new(field) }
-  let(:field_2) { "desc_metadata__viewdate_ssm" }
+  let(:field_2) { "desc_metadata__viewDate_ssm" }
 
   context "#to_s" do
     before do


### PR DESCRIPTION
Removed unnecessary comma in side menu, changed the info on the index page and sidebar and made it format correctly. This had to be done by changing the way we do it for facets but only slightly. Also makes thumbnails on index and side menu clickable links that take you to the show page for that item.

Fixes #186 
Fixes #191 
Fixes #192 