### PR TITLE
Fixes comma showing up in side menu.

### DIFF
--- a/app/assets/javascripts/blacklight-maps-browse.js
+++ b/app/assets/javascripts/blacklight-maps-browse.js
@@ -167,13 +167,12 @@
     function buildList(placenames){
       var html = "";
       var href = "";
-      $.each(placenames, function(i,val){
-        html += "<ul class='sidebar-list'>";
-        html += val;
-        html += "</ul>";
-        html = html.replace("\n,","");
+      $.each(placenames, function(key, array){
+        $.each(array, function(index, value){
+          html += value;
+        });
       });
-      return html 
+      return html;
     }
 
     // Generates placenames object


### PR DESCRIPTION
Fixes the comma showing up in the side menu. Was an issue with parsing the placenames object. Val was an array so iterating over the array was necessary.