### PR TITLE
Proposition for possible first frame grab

### DIFF
--- a/app/assets/javascripts/update_map.js.coffee
+++ b/app/assets/javascripts/update_map.js.coffee
@@ -14,6 +14,7 @@ class UserUpdater
   constructor: ->
   user_found: =>
     @found = true
+    self.map_moved
   map_moved: (e) =>
     return unless @found == true
     bounds = window.map.getBounds()


### PR DESCRIPTION
So it looks like, map_moved, which I assume does the grab of the dots within the frame, is only called on moveend. It seems like a way we could extend it to the first time you visit the application is by after it finds the user location, it calls map_moved to grab the first frames data. @terrellt Does this sound accurate?