### PR TITLE
Added workaround for _version_

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -42,10 +42,12 @@ class SolrDocument
   end
 
   def build_link(field)
-    Array(self[field]).map do |value|
-      BuildingOregon::ControlledValue.new(value).to_s
-    end.select do |value|
-      !value.to_s.start_with?("http")
+    unless field[0] == "_"
+      Array(self[field]).map do |value|
+        BuildingOregon::ControlledValue.new(value).to_s
+      end.select do |value|
+        !value.to_s.start_with?("http")
+      end
     end
   end
   


### PR DESCRIPTION
New field _version_ was indexed, so we need to skip it when parsing.