### PR TITLE
uses try catch and splits on args to check whether json was passed in.

### DIFF
--- a/app/assets/javascripts/update_map.js.coffee
+++ b/app/assets/javascripts/update_map.js.coffee
@@ -22,12 +22,20 @@ class UserUpdater
     north_east = bounds._northEast
     if @frameRequest?
       @frameRequest.abort()
-    @frameRequest = $.getJSON("/geo/frame", $.extend({}, {southwest: "#{south_west.lat},#{south_west.lng}", northeast: "#{north_east.lat},#{north_east.lng}"}, this.current_params()), this.update_frame)
+    @frameRequest = $.getJSON("/geo/frame", $.extend({}, {southwest: "#{south_west.lat},#{south_west.lng}", northeast: "#{north_east.lat},#{north_east.lng}"}, JSON.parse(this.current_params())), this.update_frame)
   current_params: ->
     param_string = unescape(window.location.search.replace("?", "")).replace(/\+/g, " ")
+    has_json = false
+    pieces = param_string.split "="
+    for arg in pieces
+     try
+       JSON.parse(arg)
+       has_json = true
+     catch error
+       has_json = false
     clean_string = decodeURI(param_string.replace(/&/g, "\",\"").replace(/\=/g,"\":\""))
-    if clean_string != ""
-      JSON.parse('{"' + clean_string + '"}')
+    if clean_string != "" && !has_json
+      '{"' + clean_string + '"}'
     else
       {}
   set_coordinates: (coordinates) ->


### PR DESCRIPTION
This uses a try catch loop to determine if valid JSON was passed into the params for `window.location.search` this is to protect from JSON injection (DOM-based). if it sees valid json it returns false and then will have an empty hash as the params. If it doesnt, it uses the data per usual. Parsing JSON later.